### PR TITLE
2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,24 +4,38 @@
 
 ## Create and update encrypted content or decrypt encrypted content in YAML files
 
-<https://blog.edlitmus.info/generate-secure-pillar/>
+<https://github.com/Everbridge/generate-secure-pillar/wiki/stupid-command-line-tricks>
 
 ## USAGE
 
    generate-secure-pillar [command] [flags]
 
-## VERSION 1.0.640
+## VERSION 2.0.0
 
 ## AUTHOR
 
-   Ed Silva <ed.silva@everbridge.com>
+   Ed Silva <ed.silva@everbridge.com>/<ed@edlitmus.info>
+
+## REQUIREMENTS
+
+GnuPG 2.x is required. This version uses `gpg --export` and `gpg --export-secret-keys` to read keys from the GnuPG agent, replacing the direct keyring file access used in 1.x.
+
+The `gpg` (or `gpg2`) binary must be available in your `PATH`.
 
 ## HOMEBREW INSTALL
 
 ``` shell
-brew tap esilva-everbridge/homebrew-generate-secure-pillar
+brew tap ed-silva-eb/homebrew-generate-secure-pillar
 brew install generate-secure-pillar
 ```
+
+## UPGRADING FROM 1.x
+
+Version 2.0 drops support for GnuPG 1.x and the legacy `secring.gpg`/`pubring.gpg` keyring files. Keys are now read from the GnuPG 2.x agent via `gpg --export` and `gpg --export-secret-keys`.
+
+The `--pubring` and `--secring` CLI flags have been replaced by `--gnupg-home` (defaults to `~/.gnupg`, or the `GNUPGHOME` environment variable).
+
+Config file profiles no longer use `default_pub_ring` or `default_sec_ring`; only `gnupg_home` and `default_key` are needed.
 
 ## CONFIG FILE USAGE
 
@@ -69,8 +83,7 @@ expect -c "spawn gpg --edit-key '<the PGP key id here>' trust quit; send \"5\ry\
 
 - `--config string`            config file (default is $HOME/.config/generate-secure-pillar/config.yaml)
 - `--profile string`           profile name from profile specified in the config file
-- `--pubring string`           PGP public keyring (default is $HOME/.gnupg/pubring.gpg)
-- `--secring string`           PGP private keyring (default is $HOME/.gnupg/secring.gpg)  
+- `--gnupg-home string`        GnuPG home directory (default is $HOME/.gnupg or $GNUPGHOME)
 - `-k, --pgp_key string`       PGP key name, email, or ID to use for encryption
 - `-e, --element string`       Name of the top level element under which encrypted key/value pairs are kept
 - `-h, --help`                 help for generate-secure-pillar
@@ -87,83 +100,83 @@ expect -c "spawn gpg --edit-key '<the PGP key id here>' trust quit; send \"5\ry\
 ### specify a config profile and create a new file
 
 ```bash
-$ generate-secure-pillar --profile dev create -n secret_name1 -s secret_value1 -n secret_name2 -s secret_value2 -o new.sls
+generate-secure-pillar --profile dev create -n secret_name1 -s secret_value1 -n secret_name2 -s secret_value2 -o new.sls
 ```
 
 ### create a new sls file
 
 ```bash
-$ generate-secure-pillar -k "Salt Master" create -n secret_name1 -s secret_value1 -n secret_name2 -s secret_value2 -o new.sls
+generate-secure-pillar -k "Salt Master" create -n secret_name1 -s secret_value1 -n secret_name2 -s secret_value2 -o new.sls
 ```
 
 ### add to the new file
 
 ```bash
-$ generate-secure-pillar -k "Salt Master" update -n new_secret_name -s new_secret_value -f new.sls
+generate-secure-pillar -k "Salt Master" update -n new_secret_name -s new_secret_value -f new.sls
 ```
 
 ### update an existing value
 
 ```bash
-$ generate-secure-pillar -k "Salt Master" update -n secret_name -s secret_value3 -f new.sls
+generate-secure-pillar -k "Salt Master" update -n secret_name -s secret_value3 -f new.sls
 ```
 
 ### encrypt all plain text values in a file
 
 ```bash
-$ generate-secure-pillar -k "Salt Master" encrypt all -f us1.sls -o us1.sls
+generate-secure-pillar -k "Salt Master" encrypt all -f us1.sls -o us1.sls
 ```
 
 ### or use --update flag
 
 ```bash
-$ generate-secure-pillar -k "Salt Master" encrypt all -f us1.sls --update
+generate-secure-pillar -k "Salt Master" encrypt all -f us1.sls --update
 ```
 
 ### encrypt all plain text values in a file under the element 'secret_stuff'
 
 ```bash
-$ generate-secure-pillar -k "Salt Master" --element secret_stuff encrypt all -f us1.sls -o us1.sls
+generate-secure-pillar -k "Salt Master" --element secret_stuff encrypt all -f us1.sls -o us1.sls
 ```
 
 ### recurse through all sls files, encrypting all values
 
 ```bash
-$ generate-secure-pillar -k "Salt Master" encrypt recurse -d /path/to/pillar/secure/stuff
+generate-secure-pillar -k "Salt Master" encrypt recurse -d /path/to/pillar/secure/stuff
 ```
 
-### recurse through all sls files, decrypting all values (requires imported private key)
+### recurse through all sls files, decrypting all values
 
 ```bash
-$ generate-secure-pillar decrypt recurse -d /path/to/pillar/secure/stuff
+generate-secure-pillar decrypt recurse -d /path/to/pillar/secure/stuff
 ```
 
-### decrypt a specific existing value (requires imported private key)
+### decrypt a specific existing value
 
 ```bash
-$ generate-secure-pillar decrypt path --path "some:yaml:path" -f new.sls
+generate-secure-pillar decrypt path --path "some:yaml:path" -f new.sls
 ```
 
-### decrypt all files and re-encrypt with given key (requires imported private key)
+### decrypt all files and re-encrypt with given key
 
 ```bash
-$ generate-secure-pillar -k "New Salt Master Key" rotate -d /path/to/pillar/secure/stuff
+generate-secure-pillar -k "New Salt Master Key" rotate -d /path/to/pillar/secure/stuff
 ```
 
 ### show all PGP key IDs used in a file
 
 ```bash
-$ generate-secure-pillar keys all -f us1.sls
+generate-secure-pillar keys all -f us1.sls
 ```
 
 ### show all keys used in all files in a given directory
 
 ```bash
-$ generate-secure-pillar keys recurse -d /path/to/pillar/secure/stuff
+generate-secure-pillar keys recurse -d /path/to/pillar/secure/stuff
 ```
 
 ### show the PGP key ID used for an element at a path in a file
 
 ```bash
-$ generate-secure-pillar keys path --path "some:yaml:path" -f new.sls
+generate-secure-pillar keys path --path "some:yaml:path" -f new.sls
 ```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,7 +34,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	tilde "gopkg.in/mattes/go-expand-tilde.v1"
 )
 
 // initLogger initializes a logger instance for the cmd package
@@ -55,10 +54,9 @@ var (
 	yamlPath       string
 
 	// Profile and encryption configuration
-	profile         string
-	pgpKeyName      string
-	publicKeyRing   = "~/.gnupg/pubring.gpg"
-	privateKeyRing  = "~/.gnupg/secring.gpg"
+	profile    string
+	pgpKeyName string
+	gnupgHome  = "~/.gnupg"
 	topLevelElement string
 
 	// Operation flags
@@ -93,13 +91,13 @@ $ generate-secure-pillar -k "Salt Master" --element secret_stuff encrypt all --f
 # recurse through all sls files, encrypting all values
 $ generate-secure-pillar -k "Salt Master" encrypt recurse -d /path/to/pillar/secure/stuff
 
-# recurse through all sls files, decrypting all values (requires imported private key)
+# recurse through all sls files, decrypting all values (requires secret key in gpg-agent)
 $ generate-secure-pillar decrypt recurse -d /path/to/pillar/secure/stuff
 
-# decrypt a specific existing value (requires imported private key)
+# decrypt a specific existing value (requires secret key in gpg-agent)
 $ generate-secure-pillar decrypt path --path "some:yaml:path" --file new.sls
 
-# decrypt all files and re-encrypt with given key (requires imported private key)
+# decrypt all files and re-encrypt with given key (requires secret key in gpg-agent)
 $ generate-secure-pillar -k "New Salt Master Key" rotate -d /path/to/pillar/secure/stuff
 
 # show all PGP key IDs used in a file
@@ -111,7 +109,7 @@ $ generate-secure-pillar keys recurse -d /path/to/pillar/secure/stuff
 # show the PGP Key ID used for an element at a path in a file
 $ generate-secure-pillar keys path --path "some:yaml:path" --file new.sls
 `,
-	Version: "1.0.640",
+	Version: "2.0.0",
 }
 
 const all = "all"
@@ -132,32 +130,16 @@ func init() {
 	cobra.OnInitialize(initConfig)
 
 	// respect the env var if set
-	gpgHome := os.Getenv("GNUPGHOME")
-	if gpgHome != "" {
-		publicKeyRing = fmt.Sprintf("%s/pubring.gpg", gpgHome)
-		privateKeyRing = fmt.Sprintf("%s/secring.gpg", gpgHome)
-	}
-
-	// check for GNUPG1 pubring file
-	filePath, err := tilde.Expand(publicKeyRing)
-	if err != nil {
-		logger.Fatal().Err(err).Msg("Error with GNUPG pubring path")
-	}
-	if utils.ContainsDirectoryTraversal(filePath) {
-		logger.Fatal().Msgf("Invalid pubring path: directory traversal detected in %s", filePath)
-	}
-	if _, err = os.Stat(filepath.Clean(filePath)); os.IsNotExist(err) {
-		if err != nil {
-			logger.Fatal().Err(err).Msg("Error finding GNUPG pubring file")
-		}
+	gpgHomeEnv := os.Getenv("GNUPGHOME")
+	if gpgHomeEnv != "" {
+		gnupgHome = gpgHomeEnv
 	}
 
 	rootCmd.PersistentFlags().Bool("version", false, "print the version")
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.config/generate-secure-pillar/config.yaml)")
 	rootCmd.PersistentFlags().StringVar(&profile, "profile", "", "profile name from profile specified in the config file")
 	rootCmd.PersistentFlags().StringVarP(&pgpKeyName, "pgp_key", "k", pgpKeyName, "PGP key name, email, or ID to use for encryption")
-	rootCmd.PersistentFlags().StringVar(&publicKeyRing, "pubring", publicKeyRing, "PGP public keyring (default is $HOME/.gnupg/pubring.gpg)")
-	rootCmd.PersistentFlags().StringVar(&privateKeyRing, "secring", privateKeyRing, "PGP private keyring (default is $HOME/.gnupg/secring.gpg)")
+	rootCmd.PersistentFlags().StringVar(&gnupgHome, "gnupg-home", gnupgHome, "GnuPG home directory (default is $HOME/.gnupg)")
 	rootCmd.PersistentFlags().StringVarP(&topLevelElement, "element", "e", "", "Name of the top level element under which encrypted key/value pairs are kept")
 }
 
@@ -206,7 +188,7 @@ func initConfig() {
 }
 
 func getPki() *pki.Pki {
-	p, err := pki.New(pgpKeyName, publicKeyRing, privateKeyRing)
+	p, err := pki.New(pgpKeyName, gnupgHome)
 	if err != nil {
 		logger.Fatal().Err(err).Msg("failed to initialize PKI")
 	}
@@ -241,8 +223,7 @@ func readProfile() {
 								logger.Warn().Msgf("Invalid gnupg_home path: directory traversal detected in %s", gpgHome)
 								continue
 							}
-							publicKeyRing = fmt.Sprintf("%s/pubring.gpg", gpgHome)
-							privateKeyRing = fmt.Sprintf("%s/secring.gpg", gpgHome)
+							gnupgHome = gpgHome
 						}
 					}
 					if defaultKeyVal, exists := profileMap["default_key"]; exists && defaultKeyVal != nil {

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -3,19 +3,13 @@ profiles:
     default: true
     default_key: Dev Salt Master
     gnupg_home: ~/.gnupg
-    default_pub_ring: ~/.gnupg/pubring.gpg
-    default_sec_ring: ~/.gnupg/secring.gpg
 
   - name: stage
     default: false
     default_key: Stage Salt Master
     gnupg_home: ~/.gnupg
-    default_pub_ring: ~/.gnupg/pubring.gpg
-    default_sec_ring: ~/.gnupg/secring.gpg
 
   - name: prod
     default: false
     default_key: Prod Salt Master
     gnupg_home: ~/.gnupg
-    default_pub_ring: ~/.gnupg/pubring.gpg
-    default_sec_ring: ~/.gnupg/secring.gpg

--- a/go.mod
+++ b/go.mod
@@ -6,13 +6,12 @@ require (
 	github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
 	github.com/edlitmus/ezyaml v0.0.0-20231025150529-6f3a38cc5cf6
 	github.com/esilva-everbridge/yaml v0.0.0-20230222145725-586d68d00607
-	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
+	github.com/ProtonMail/go-crypto v1.1.6
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/rs/zerolog v1.31.0
 	github.com/ryboe/q v1.0.19
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.15.0
-	gopkg.in/mattes/go-expand-tilde.v1 v1.0.0-20150330173918-cb884138e64c
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -39,7 +38,9 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
-	golang.org/x/sys v0.12.0 // indirect
-	golang.org/x/text v0.5.0 // indirect
+	github.com/cloudflare/circl v1.3.7 // indirect
+	golang.org/x/crypto v0.28.0 // indirect
+	golang.org/x/sys v0.26.0 // indirect
+	golang.org/x/text v0.19.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,10 @@ module github.com/Everbridge/generate-secure-pillar
 go 1.21
 
 require (
+	github.com/ProtonMail/go-crypto v1.1.6
 	github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
 	github.com/edlitmus/ezyaml v0.0.0-20231025150529-6f3a38cc5cf6
 	github.com/esilva-everbridge/yaml v0.0.0-20230222145725-586d68d00607
-	github.com/ProtonMail/go-crypto v1.1.6
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/rs/zerolog v1.31.0
 	github.com/ryboe/q v1.0.19
@@ -16,6 +16,7 @@ require (
 )
 
 require (
+	github.com/cloudflare/circl v1.3.7 // indirect
 	github.com/edlitmus/dig v0.0.0-20231025150220-13b7e66ce5ac // indirect
 	github.com/edlitmus/to v0.0.0-20231025141937-dd8488388a59 // indirect
 	github.com/esilva-everbridge/dig v0.0.0-20230222145646-42ad4ced5ae3 // indirect
@@ -38,7 +39,6 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
-	github.com/cloudflare/circl v1.3.7 // indirect
 	golang.org/x/crypto v0.28.0 // indirect
 	golang.org/x/sys v0.26.0 // indirect
 	golang.org/x/text v0.19.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3f
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/ProtonMail/go-crypto v1.1.6 h1:ZcV+Ropw6Qn0AX9brlQLAUXfqLBc7Bl+f/DmNxpLfdw=
+github.com/ProtonMail/go-crypto v1.1.6/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -45,6 +47,8 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
+github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
@@ -146,8 +150,6 @@ github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7P
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
-github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4 h1:cTxwSmnaqLoo+4tLukHoB9iqHOu3LmLhRmgUxZo6Vp4=
-github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4/go.mod h1:ghbZscTyKdM07+Fw3KSi0hcJm+AlEUWj8QLlPtijN/M=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -233,6 +235,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.28.0 h1:GBDwsMXVQi34v5CCYUm2jkJvu4cbtru2U4TN2PSyQnw=
+golang.org/x/crypto v0.28.0/go.mod h1:rmgy+3RHxRZMyY0jjAJShp2zgEdOqj2AO7U0pYmeQ7U=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -353,8 +357,9 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
 golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
+golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -362,8 +367,8 @@ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.5.0 h1:OLmvp0KP+FVG99Ct/qFiL/Fhk4zp4QQnZ7b2U+5piUM=
-golang.org/x/text v0.5.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
+golang.org/x/text v0.19.0 h1:kTxAhCbGbxhK0IwgSKiMO5awPoDQ0RpfiVYBfK860YM=
+golang.org/x/text v0.19.0/go.mod h1:BuEKDfySbSR4drPmRPG/7iBdf8hvFMuRexcpahXilzY=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -514,8 +519,6 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EV
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
-gopkg.in/mattes/go-expand-tilde.v1 v1.0.0-20150330173918-cb884138e64c h1:/Onz8dZtKBCmB8P0JU7+WSCfMekXry7BflVO0SQQrCU=
-gopkg.in/mattes/go-expand-tilde.v1 v1.0.0-20150330173918-cb884138e64c/go.mod h1:j6QavCO5cYWud1+2/PFTXL1y6tjjkhSs+qcWgibOIc0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main_test.go
+++ b/main_test.go
@@ -44,8 +44,7 @@ import (
 )
 
 var pgpKeyName string
-var publicKeyRing string
-var secretKeyRing string
+var gnupgHome string
 var topLevelElement string
 var update = flag.Bool("update", false, "update golden files")
 var dirPath string
@@ -64,14 +63,14 @@ func TestMain(m *testing.M) {
 }
 
 func TestCliArgs(t *testing.T) {
-	pgpKeyName, publicKeyRing, secretKeyRing = getTestKeyRings()
+	pgpKeyName, gnupgHome = getTestKeyInfo()
 	topLevelElement = ""
 	binaryName := "generate-secure-pillar"
 
 	// set up: encrypt the test sls files
 	_, slsCount := utils.FindFilesByExt(dirPath, ".sls")
 	Equals(t, 7, slsCount)
-	pk, err := pki.New(pgpKeyName, publicKeyRing, secretKeyRing)
+	pk, err := pki.New(pgpKeyName, gnupgHome)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -242,10 +241,10 @@ func keyNameCount(str string, needle string) int {
 }
 
 func TestWriteSlsFile(t *testing.T) {
-	pgpKeyName, publicKeyRing, secretKeyRing = getTestKeyRings()
+	pgpKeyName, gnupgHome = getTestKeyInfo()
 	slsFile := "./testdata/foo/foo.sls"
 
-	p, err := pki.New(pgpKeyName, publicKeyRing, secretKeyRing)
+	p, err := pki.New(pgpKeyName, gnupgHome)
 	Ok(t, err)
 	s := sls.New(slsFile, *p, topLevelElement)
 
@@ -274,7 +273,7 @@ func TestWriteSlsFile(t *testing.T) {
 }
 
 func TestReadSlsFile(t *testing.T) {
-	pgpKeyName, publicKeyRing, secretKeyRing = getTestKeyRings()
+	pgpKeyName, gnupgHome = getTestKeyInfo()
 	topLevelElement = "secure_vars"
 	yamlObj, err := yaml.Open("./testdata/new.sls")
 	Ok(t, err)
@@ -284,9 +283,9 @@ func TestReadSlsFile(t *testing.T) {
 }
 
 func TestReadIncludeFile(t *testing.T) {
-	pgpKeyName, publicKeyRing, secretKeyRing = getTestKeyRings()
+	pgpKeyName, gnupgHome = getTestKeyInfo()
 	slsFile := "./testdata/inc.sls"
-	p, err := pki.New(pgpKeyName, publicKeyRing, secretKeyRing)
+	p, err := pki.New(pgpKeyName, gnupgHome)
 	Ok(t, err)
 	s := sls.New(slsFile, *p, topLevelElement)
 	Assert(t, s.IsInclude, "failed to detect include file", s.IsInclude)
@@ -296,7 +295,7 @@ func TestReadIncludeFile(t *testing.T) {
 }
 
 func TestReadBadFile(t *testing.T) {
-	pgpKeyName, publicKeyRing, secretKeyRing = getTestKeyRings()
+	pgpKeyName, gnupgHome = getTestKeyInfo()
 	topLevelElement = "secure_vars"
 	yamlObj, err := yaml.Open("/dev/null")
 	Ok(t, err)
@@ -304,9 +303,9 @@ func TestReadBadFile(t *testing.T) {
 }
 
 func TestEncryptSecret(t *testing.T) {
-	pgpKeyName, publicKeyRing, secretKeyRing = getTestKeyRings()
+	pgpKeyName, gnupgHome = getTestKeyInfo()
 	topLevelElement = "secure_vars"
-	p, err := pki.New(pgpKeyName, publicKeyRing, secretKeyRing)
+	p, err := pki.New(pgpKeyName, gnupgHome)
 	Ok(t, err)
 
 	yamlObj, err := yaml.Open("./testdata/new.sls")
@@ -328,11 +327,11 @@ func TestEncryptSecret(t *testing.T) {
 }
 
 func TestGetPath(t *testing.T) {
-	pgpKeyName, publicKeyRing, secretKeyRing = getTestKeyRings()
+	pgpKeyName, gnupgHome = getTestKeyInfo()
 	topLevelElement = "secure_vars"
 
 	file := "./testdata/test/bar.sls"
-	p, err := pki.New(pgpKeyName, publicKeyRing, secretKeyRing)
+	p, err := pki.New(pgpKeyName, gnupgHome)
 	Ok(t, err)
 	s := sls.New(file, *p, topLevelElement)
 
@@ -359,9 +358,9 @@ func TestGetPath(t *testing.T) {
 }
 
 func TestDecryptSecret(t *testing.T) {
-	pgpKeyName, publicKeyRing, secretKeyRing = getTestKeyRings()
+	pgpKeyName, gnupgHome = getTestKeyInfo()
 	topLevelElement = "secure_vars"
-	p, err := pki.New(pgpKeyName, publicKeyRing, secretKeyRing)
+	p, err := pki.New(pgpKeyName, gnupgHome)
 	Ok(t, err)
 
 	yamlObj, err := yaml.Open("./testdata/new.sls")
@@ -382,10 +381,10 @@ func TestDecryptSecret(t *testing.T) {
 }
 
 func TestGetValueFromPath(t *testing.T) {
-	pgpKeyName, publicKeyRing, secretKeyRing = getTestKeyRings()
+	pgpKeyName, gnupgHome = getTestKeyInfo()
 
 	filePath := "./testdata/new.sls"
-	p, err := pki.New(pgpKeyName, publicKeyRing, secretKeyRing)
+	p, err := pki.New(pgpKeyName, gnupgHome)
 	Ok(t, err)
 	s := sls.New(filePath, *p, topLevelElement)
 	val := s.GetValueFromPath("bar:baz")
@@ -393,10 +392,10 @@ func TestGetValueFromPath(t *testing.T) {
 }
 
 func TestNestedAndMultiLineFile(t *testing.T) {
-	pgpKeyName, publicKeyRing, secretKeyRing = getTestKeyRings()
+	pgpKeyName, gnupgHome = getTestKeyInfo()
 
 	filePath := "./testdata/test.sls"
-	p, err := pki.New(pgpKeyName, publicKeyRing, secretKeyRing)
+	p, err := pki.New(pgpKeyName, gnupgHome)
 	Ok(t, err)
 	s := sls.New(filePath, *p, topLevelElement)
 
@@ -410,7 +409,7 @@ func TestNestedAndMultiLineFile(t *testing.T) {
 	Ok(t, err)
 
 	filePath = "./testdata/test.sls"
-	p, err = pki.New(pgpKeyName, publicKeyRing, secretKeyRing)
+	p, err = pki.New(pgpKeyName, gnupgHome)
 	Ok(t, err)
 	s = sls.New(filePath, *p, topLevelElement)
 
@@ -425,10 +424,10 @@ func TestNestedAndMultiLineFile(t *testing.T) {
 }
 
 func TestSetValueFromPath(t *testing.T) {
-	pgpKeyName, publicKeyRing, secretKeyRing = getTestKeyRings()
+	pgpKeyName, gnupgHome = getTestKeyInfo()
 
 	filePath := "./testdata/new.sls"
-	p, err := pki.New(pgpKeyName, publicKeyRing, secretKeyRing)
+	p, err := pki.New(pgpKeyName, gnupgHome)
 	Ok(t, err)
 	s := sls.New(filePath, *p, topLevelElement)
 
@@ -440,11 +439,11 @@ func TestSetValueFromPath(t *testing.T) {
 }
 
 func TestRotateFile(t *testing.T) {
-	pgpKeyName, publicKeyRing, secretKeyRing = getTestKeyRings()
+	pgpKeyName, gnupgHome = getTestKeyInfo()
 	topLevelElement = ""
 
 	filePath := "./testdata/new.sls"
-	p, err := pki.New(pgpKeyName, publicKeyRing, secretKeyRing)
+	p, err := pki.New(pgpKeyName, gnupgHome)
 	Ok(t, err)
 	s := sls.New(filePath, *p, topLevelElement)
 
@@ -470,11 +469,11 @@ func TestRotateFile(t *testing.T) {
 }
 
 func TestKeyInfo(t *testing.T) {
-	pgpKeyName, publicKeyRing, secretKeyRing = getTestKeyRings()
+	pgpKeyName, gnupgHome = getTestKeyInfo()
 	topLevelElement = ""
 
 	filePath := "./testdata/new.sls"
-	p, err := pki.New(pgpKeyName, publicKeyRing, secretKeyRing)
+	p, err := pki.New(pgpKeyName, gnupgHome)
 	Ok(t, err)
 	s := sls.New(filePath, *p, topLevelElement)
 
@@ -502,14 +501,14 @@ func TestKeyInfo(t *testing.T) {
 }
 
 func TestEncryptProcessDir(t *testing.T) {
-	pgpKeyName, publicKeyRing, secretKeyRing = getTestKeyRings()
+	pgpKeyName, gnupgHome = getTestKeyInfo()
 	topLevelElement = ""
 
 	dirPath := "./testdata"
 	slsFiles, slsCount := utils.FindFilesByExt(dirPath, ".sls")
 	Equals(t, 7, slsCount)
 
-	pk, err := pki.New(pgpKeyName, publicKeyRing, secretKeyRing)
+	pk, err := pki.New(pgpKeyName, gnupgHome)
 	Ok(t, err)
 	err = utils.ProcessDir(dirPath, ".sls", sls.Encrypt, "", topLevelElement, *pk)
 	Ok(t, err)
@@ -535,14 +534,14 @@ func TestEncryptProcessDir(t *testing.T) {
 }
 
 func TestDecryptProcessDir(t *testing.T) {
-	pgpKeyName, publicKeyRing, secretKeyRing = getTestKeyRings()
+	pgpKeyName, gnupgHome = getTestKeyInfo()
 	topLevelElement = ""
 
 	dirPath := "./testdata"
 	slsFiles, slsCount := utils.FindFilesByExt(dirPath, ".sls")
 	Equals(t, 7, slsCount)
 
-	pk, err := pki.New(pgpKeyName, publicKeyRing, secretKeyRing)
+	pk, err := pki.New(pgpKeyName, gnupgHome)
 	Ok(t, err)
 	err = utils.ProcessDir(dirPath, ".sls", sls.Decrypt, "", topLevelElement, *pk)
 	Ok(t, err)
@@ -630,35 +629,37 @@ func Equals(tb testing.TB, exp, act interface{}) {
 func initGPGDir() {
 	teardownGPGDir()
 	dirPath, _ = filepath.Abs("./testdata")
-	os.Setenv("GNUPGHOME", dirPath+"/gnupg")
+	gnupgDir := dirPath + "/gnupg"
+	os.Setenv("GNUPGHOME", gnupgDir)
 	cmd := exec.Command("./testdata/testkeys.sh")
 	out, _ := cmd.CombinedOutput()
 	fmt.Printf("%s", string(out))
 }
 
 func teardownGPGDir() {
-	_ = os.Remove("./testdata/gnupg/pubring.gpg")
-	_ = os.Remove("./testdata/gnupg/pubring.gpg~")
-	_ = os.Remove("./testdata/gnupg/random_seed")
-	_ = os.Remove("./testdata/gnupg/secring.gpg")
-	_ = os.Remove("./testdata/gnupg/trustdb.gpg")
+	gnupgDir, _ := filepath.Abs("./testdata/gnupg")
+	// Remove all files in the gnupg directory but keep the directory itself
+	entries, err := os.ReadDir(gnupgDir)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		if entry.Name() == ".gitkeep" {
+			continue
+		}
+		os.RemoveAll(filepath.Join(gnupgDir, entry.Name()))
+	}
 }
 
-func getTestKeyRings() (pgpKeyName string, publicKeyRing string, secretKeyRing string) {
+func getTestKeyInfo() (pgpKeyName string, gnupgHome string) {
 	pgpKeyName = "Test Salt Master"
-	if os.Getenv("SALT_SEC_KEYRING") != "" {
-		publicKeyRing, _ = filepath.Abs(os.Getenv("SALT_PUB_KEYRING"))
+	if os.Getenv("GNUPGHOME") != "" {
+		gnupgHome = os.Getenv("GNUPGHOME")
 	} else {
-		publicKeyRing = "./testdata/gnupg/pubring.gpg"
+		gnupgHome, _ = filepath.Abs("./testdata/gnupg")
 	}
 
-	if os.Getenv("SALT_SEC_KEYRING") != "" {
-		secretKeyRing, _ = filepath.Abs(os.Getenv("SALT_SEC_KEYRING"))
-	} else {
-		secretKeyRing = "./testdata/gnupg/secring.gpg"
-	}
-
-	return pgpKeyName, publicKeyRing, secretKeyRing
+	return pgpKeyName, gnupgHome
 }
 
 func fixturePath(t *testing.T, fixture string) string {
@@ -688,10 +689,10 @@ func loadFixture(t *testing.T, fixture string) string {
 
 // TestEncryptionRobustness tests encryption with various data types and edge cases
 func TestEncryptionRobustness(t *testing.T) {
-	pgpKeyName, publicKeyRing, secretKeyRing := getTestKeyRings()
+	pgpKeyName, gnupgHome := getTestKeyInfo()
 	topLevelElement = ""
 
-	p, err := pki.New(pgpKeyName, publicKeyRing, secretKeyRing)
+	p, err := pki.New(pgpKeyName, gnupgHome)
 	Ok(t, err)
 
 	tests := []struct {
@@ -739,43 +740,33 @@ func TestEncryptionRobustness(t *testing.T) {
 
 // TestPKIEdgeCases tests PKI operations with edge cases
 func TestPKIEdgeCases(t *testing.T) {
+	_, validGnupgHome := getTestKeyInfo()
+
 	tests := []struct {
 		name        string
 		keyName     string
-		pubKeyring  string
-		secKeyring  string
+		gnupgHome   string
 		wantErr     bool
 		errContains string
 	}{
 		{
-			name:        "missing public keyring",
+			name:        "nonexistent gnupg home",
 			keyName:     "Test Salt Master",
-			pubKeyring:  "/nonexistent/pubring.gpg",
-			secKeyring:  "./testdata/gnupg/secring.gpg",
+			gnupgHome:   "/nonexistent/gnupg",
 			wantErr:     true,
-			errContains: "no such file",
-		},
-		{
-			name:        "missing secret keyring",
-			keyName:     "Test Salt Master",
-			pubKeyring:  "./testdata/gnupg/pubring.gpg",
-			secKeyring:  "/nonexistent/secring.gpg",
-			wantErr:     false, // PKI just warns about missing secret keyring, doesn't error
-			errContains: "",
+			errContains: "not accessible",
 		},
 		{
 			name:        "empty key name",
 			keyName:     "",
-			pubKeyring:  "./testdata/gnupg/pubring.gpg",
-			secKeyring:  "./testdata/gnupg/secring.gpg",
+			gnupgHome:   validGnupgHome,
 			wantErr:     true,
 			errContains: "",
 		},
 		{
 			name:        "nonexistent key name",
 			keyName:     "Nonexistent Key",
-			pubKeyring:  "./testdata/gnupg/pubring.gpg",
-			secKeyring:  "./testdata/gnupg/secring.gpg",
+			gnupgHome:   validGnupgHome,
 			wantErr:     true,
 			errContains: "unable to find key",
 		},
@@ -783,7 +774,7 @@ func TestPKIEdgeCases(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := pki.New(tt.keyName, tt.pubKeyring, tt.secKeyring)
+			_, err := pki.New(tt.keyName, tt.gnupgHome)
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("pki.New() error = %v, wantErr %v", err, tt.wantErr)
@@ -801,10 +792,10 @@ func TestPKIEdgeCases(t *testing.T) {
 
 // TestSlsFileEdgeCases tests SLS file handling with edge cases
 func TestSlsFileEdgeCases(t *testing.T) {
-	pgpKeyName, publicKeyRing, secretKeyRing := getTestKeyRings()
+	pgpKeyName, gnupgHome := getTestKeyInfo()
 	topLevelElement = ""
 
-	p, err := pki.New(pgpKeyName, publicKeyRing, secretKeyRing)
+	p, err := pki.New(pgpKeyName, gnupgHome)
 	Ok(t, err)
 
 	tempDir := t.TempDir()
@@ -891,11 +882,11 @@ nested:
 
 // TestPathOperationsEdgeCases tests YAML path operations with edge cases
 func TestPathOperationsEdgeCases(t *testing.T) {
-	pgpKeyName, publicKeyRing, secretKeyRing := getTestKeyRings()
+	pgpKeyName, gnupgHome := getTestKeyInfo()
 	topLevelElement = ""
 
 	filePath := "./testdata/new.sls"
-	p, err := pki.New(pgpKeyName, publicKeyRing, secretKeyRing)
+	p, err := pki.New(pgpKeyName, gnupgHome)
 	Ok(t, err)
 	s := sls.New(filePath, *p, topLevelElement)
 
@@ -940,10 +931,10 @@ func TestConcurrentOperations(t *testing.T) {
 		t.Skip("Skipping concurrent test in short mode")
 	}
 
-	pgpKeyName, publicKeyRing, secretKeyRing := getTestKeyRings()
+	pgpKeyName, gnupgHome := getTestKeyInfo()
 	topLevelElement = ""
 
-	p, err := pki.New(pgpKeyName, publicKeyRing, secretKeyRing)
+	p, err := pki.New(pgpKeyName, gnupgHome)
 	Ok(t, err)
 
 	tempDir := t.TempDir()

--- a/pki/pki.go
+++ b/pki/pki.go
@@ -22,18 +22,19 @@
 package pki
 
 import (
-	"bufio"
 	"bytes"
+	"bufio"
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"os/user"
 	"path/filepath"
 	"strings"
 	"time"
 
-	"github.com/keybase/go-crypto/openpgp"
-	"github.com/keybase/go-crypto/openpgp/armor"
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/armor"
 	"github.com/rs/zerolog"
 	"github.com/ryboe/q"
 )
@@ -43,15 +44,14 @@ const PGPHeader string = "-----BEGIN PGP MESSAGE-----"
 
 // Pki pki info
 type Pki struct {
-	PublicKey     *openpgp.Entity
-	SecretKey     *openpgp.Entity
-	PubRing       *openpgp.EntityList
-	SecRing       *openpgp.EntityList
-	PublicKeyRing string
-	SecretKeyRing string
-	PgpKeyName    string
-	logger        zerolog.Logger
-	debug         bool
+	PublicKey  *openpgp.Entity
+	SecretKey  *openpgp.Entity
+	PubRing   *openpgp.EntityList
+	SecRing   *openpgp.EntityList
+	GnupgHome string
+	PgpKeyName string
+	logger     zerolog.Logger
+	debug      bool
 }
 
 // dbg creates a debug dumper function
@@ -63,63 +63,104 @@ func (p *Pki) dbg() func(thing ...interface{}) {
 	}
 }
 
+// findGPGBinary locates the gpg binary, preferring gpg2
+func findGPGBinary() (string, error) {
+	for _, name := range []string{"gpg2", "gpg"} {
+		path, err := exec.LookPath(name)
+		if err == nil {
+			return path, nil
+		}
+	}
+	return "", fmt.Errorf("cannot find gpg or gpg2 binary in PATH")
+}
+
+// exportKeysFromGPG runs gpg to export keys and returns them as an EntityList
+func exportKeysFromGPG(gnupgHome string, secret bool) (*openpgp.EntityList, error) {
+	gpgBin, err := findGPGBinary()
+	if err != nil {
+		return nil, err
+	}
+
+	args := []string{"--homedir", gnupgHome, "--batch", "--yes", "--export"}
+	if secret {
+		args = []string{"--homedir", gnupgHome, "--batch", "--yes", "--export-secret-keys"}
+	}
+
+	cmd := exec.Command(gpgBin, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("gpg export failed: %w: %s", err, stderr.String())
+	}
+
+	if stdout.Len() == 0 {
+		return nil, fmt.Errorf("gpg exported zero bytes (no keys found in %s)", gnupgHome)
+	}
+
+	ring, err := openpgp.ReadKeyRing(&stdout)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse exported keys: %w", err)
+	}
+	if ring == nil {
+		return nil, fmt.Errorf("exported keyring is empty")
+	}
+
+	return &ring, nil
+}
+
 // New returns a pki object and an error
-func New(pgpKeyName string, publicKeyRing string, secretKeyRing string) (*Pki, error) {
+func New(pgpKeyName string, gnupgHome string) (*Pki, error) {
 	// Initialize logger
 	logger := zerolog.New(os.Stdout).Output(zerolog.ConsoleWriter{Out: os.Stdout})
 
 	// Check for debug mode
 	debugMode := os.Getenv("GSPPKI_DEBUG") != ""
 
-	var err error
-
 	// Validate input parameters
 	if pgpKeyName == "" {
 		return nil, fmt.Errorf("PGP key name cannot be empty")
 	}
-	if publicKeyRing == "" {
-		return nil, fmt.Errorf("public key ring path cannot be empty")
-	}
-	if secretKeyRing == "" {
-		return nil, fmt.Errorf("secret key ring path cannot be empty")
+	if gnupgHome == "" {
+		return nil, fmt.Errorf("GnuPG home directory cannot be empty")
 	}
 
 	p := &Pki{
-		PublicKey:     nil,
-		SecretKey:     nil,
-		PubRing:       nil,
-		SecRing:       nil,
-		PublicKeyRing: publicKeyRing,
-		SecretKeyRing: secretKeyRing,
-		PgpKeyName:    pgpKeyName,
-		logger:        logger,
-		debug:         debugMode,
+		PublicKey:  nil,
+		SecretKey:  nil,
+		PubRing:    nil,
+		SecRing:    nil,
+		GnupgHome: gnupgHome,
+		PgpKeyName: pgpKeyName,
+		logger:     logger,
+		debug:      debugMode,
 	}
 
-	// Expand and validate public key ring path
-	publicKeyRing, err = p.ExpandTilde(p.PublicKeyRing)
+	// Expand tilde in gnupg home path
+	expandedHome, err := p.ExpandTilde(gnupgHome)
 	if err != nil {
-		return nil, fmt.Errorf("cannot expand public key ring path: %w", err)
+		return nil, fmt.Errorf("cannot expand GnuPG home path: %w", err)
 	}
-	p.PublicKeyRing = publicKeyRing
+	p.GnupgHome = expandedHome
 
-	// Load public key ring
-	p.PubRing, err = p.setKeyRing(p.PublicKeyRing)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load public key ring '%s': %w", p.PublicKeyRing, err)
+	// Verify the GnuPG home directory exists
+	if fi, err := os.Stat(p.GnupgHome); err != nil {
+		return nil, fmt.Errorf("GnuPG home directory '%s' not accessible: %w", p.GnupgHome, err)
+	} else if !fi.IsDir() {
+		return nil, fmt.Errorf("GnuPG home '%s' is not a directory", p.GnupgHome)
 	}
 
-	// Expand and validate secret key ring path
-	secKeyRing, err := p.ExpandTilde(p.SecretKeyRing)
+	// Export public keys from GnuPG
+	p.PubRing, err = exportKeysFromGPG(p.GnupgHome, false)
 	if err != nil {
-		return nil, fmt.Errorf("cannot expand secret key ring path: %w", err)
+		return nil, fmt.Errorf("failed to export public keys: %w", err)
 	}
-	p.SecretKeyRing = secKeyRing
 
-	// Load secret key ring (this may fail and is non-fatal for encryption-only operations)
-	p.SecRing, err = p.setKeyRing(p.SecretKeyRing)
+	// Export secret keys from GnuPG (non-fatal if it fails)
+	p.SecRing, err = exportKeysFromGPG(p.GnupgHome, true)
 	if err != nil {
-		p.logger.Warn().Err(err).Str("keyring", p.SecretKeyRing).Msg("failed to load secret key ring - decryption operations will not be available")
+		p.logger.Warn().Err(err).Msg("failed to export secret keys - decryption operations will not be available")
 	}
 
 	// Load keys
@@ -128,7 +169,7 @@ func New(pgpKeyName string, publicKeyRing string, secretKeyRing string) (*Pki, e
 	}
 	p.PublicKey = p.GetKeyByID(p.PubRing, p.PgpKeyName)
 	if p.PublicKey == nil {
-		return nil, fmt.Errorf("unable to find key '%s' in public key ring '%s'", p.PgpKeyName, p.PublicKeyRing)
+		return nil, fmt.Errorf("unable to find key '%s' in public keyring", p.PgpKeyName)
 	}
 
 	// Debug dump if enabled
@@ -136,37 +177,6 @@ func New(pgpKeyName string, publicKeyRing string, secretKeyRing string) (*Pki, e
 	dumper(p)
 
 	return p, nil
-}
-
-func (p *Pki) setKeyRing(keyRingPath string) (*openpgp.EntityList, error) {
-	if keyRingPath == "" {
-		return nil, fmt.Errorf("key ring path cannot be empty")
-	}
-
-	keyRing, err := p.ExpandTilde(keyRingPath)
-	if err != nil {
-		return nil, fmt.Errorf("error expanding key ring path '%s': %w", keyRingPath, err)
-	}
-
-	keyRingFile, err := os.Open(filepath.Clean(keyRing))
-	if err != nil {
-		return nil, fmt.Errorf("unable to open key ring file '%s': %w", keyRing, err)
-	}
-	defer func() {
-		if closeErr := keyRingFile.Close(); closeErr != nil {
-			p.logger.Warn().Err(closeErr).Str("keyring", keyRing).Msg("failed to close key ring file")
-		}
-	}()
-
-	ring, err := openpgp.ReadKeyRing(keyRingFile)
-	if err != nil {
-		return nil, fmt.Errorf("cannot read key ring from file '%s': %w", keyRing, err)
-	}
-	if ring == nil {
-		return nil, fmt.Errorf("key ring file '%s' is empty or invalid", keyRing)
-	}
-
-	return &ring, nil
 }
 
 // EncryptSecret returns encrypted plainText
@@ -209,7 +219,7 @@ func (p *Pki) EncryptSecret(plainText string) (string, error) {
 // DecryptSecret returns decrypted cipherText
 func (p *Pki) DecryptSecret(cipherText string) (plainText string, err error) {
 	if p.SecRing == nil {
-		return cipherText, fmt.Errorf("no secring set")
+		return cipherText, fmt.Errorf("no secret keyring available")
 	}
 	if p.SecretKey == nil {
 		return cipherText, fmt.Errorf("unable to load PGP secret key for '%s'", p.PgpKeyName)
@@ -224,7 +234,7 @@ func (p *Pki) DecryptSecret(cipherText string) (plainText string, err error) {
 		return cipherText, fmt.Errorf("block type is not PGP MESSAGE: %s", err)
 	}
 
-	md, err := openpgp.ReadMessage(block.Body, p.SecRing, nil, nil)
+	md, err := openpgp.ReadMessage(block.Body, *p.SecRing, nil, nil)
 	if err != nil {
 		return cipherText, fmt.Errorf("unable to read PGP message: %s", err)
 	}
@@ -384,7 +394,7 @@ func (p *Pki) KeyUsedForEncryptedFile(file string) (string, error) {
 		return "", fmt.Errorf("invalid block type '%s', expected 'PGP MESSAGE' in file '%s'", block.Type, filePath)
 	}
 
-	md, err := openpgp.ReadMessage(block.Body, p.SecRing, nil, nil)
+	md, err := openpgp.ReadMessage(block.Body, *p.SecRing, nil, nil)
 	if err != nil {
 		return "", fmt.Errorf("unable to read PGP message from file '%s': %w", filePath, err)
 	}
@@ -408,7 +418,7 @@ func (p *Pki) keyStringForID(id uint64) string {
 		return ""
 	}
 
-	keys := p.SecRing.KeysById(id, nil)
+	keys := p.SecRing.KeysById(id)
 	if len(keys) == 0 {
 		return ""
 	}

--- a/security_test.go
+++ b/security_test.go
@@ -187,7 +187,7 @@ func TestFilePermissionHandling(t *testing.T) {
 		},
 	}
 
-	pgpKeyName, publicKeyRing, secretKeyRing := getTestKeyRings()
+	pgpKeyName, gnupgHome := getTestKeyInfo()
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -202,8 +202,7 @@ func TestFilePermissionHandling(t *testing.T) {
 			binaryPath := filepath.Join(dir, "generate-secure-pillar")
 			cmd := exec.Command(binaryPath,
 				"-k", pgpKeyName,
-				"--pubring", publicKeyRing,
-				"--secring", secretKeyRing,
+				"--gnupg-home", gnupgHome,
 				"keys", "all", "-f", filePath)
 
 			output, err := cmd.CombinedOutput()
@@ -228,7 +227,7 @@ func TestMalformedInputHandling(t *testing.T) {
 	}
 
 	tempDir := t.TempDir()
-	pgpKeyName, publicKeyRing, secretKeyRing := getTestKeyRings()
+	pgpKeyName, gnupgHome := getTestKeyInfo()
 
 	testCases := []struct {
 		name        string
@@ -241,8 +240,7 @@ func TestMalformedInputHandling(t *testing.T) {
 				outputFile := filepath.Join(tempDir, "empty_names.sls")
 				args := []string{
 					"-k", pgpKeyName,
-					"--pubring", publicKeyRing,
-					"--secring", secretKeyRing,
+					"--gnupg-home", gnupgHome,
 					"create", "-n", "", "-s", "value", "-o", outputFile,
 				}
 				return args, "secret names"
@@ -255,8 +253,7 @@ func TestMalformedInputHandling(t *testing.T) {
 				outputFile := filepath.Join(tempDir, "empty_values.sls")
 				args := []string{
 					"-k", pgpKeyName,
-					"--pubring", publicKeyRing,
-					"--secring", secretKeyRing,
+					"--gnupg-home", gnupgHome,
 					"create", "-n", "name", "-s", "", "-o", outputFile,
 				}
 				return args, ""
@@ -269,8 +266,7 @@ func TestMalformedInputHandling(t *testing.T) {
 				outputFile := filepath.Join(tempDir, "mismatched.sls")
 				args := []string{
 					"-k", pgpKeyName,
-					"--pubring", publicKeyRing,
-					"--secring", secretKeyRing,
+					"--gnupg-home", gnupgHome,
 					"create", "-n", "name1,name2", "-s", "value1", "-o", outputFile,
 				}
 				return args, "mismatch"
@@ -288,8 +284,7 @@ func TestMalformedInputHandling(t *testing.T) {
 				}
 				args := []string{
 					"-k", pgpKeyName,
-					"--pubring", publicKeyRing,
-					"--secring", secretKeyRing,
+					"--gnupg-home", gnupgHome,
 					"keys", "all", "-f", malformedFile,
 				}
 				return args, "yaml"
@@ -338,7 +333,7 @@ func TestIncludeFileHandling(t *testing.T) {
 	}
 
 	tempDir := t.TempDir()
-	pgpKeyName, publicKeyRing, secretKeyRing := getTestKeyRings()
+	pgpKeyName, gnupgHome := getTestKeyInfo()
 
 	// Create a file with include directive
 	includeFile := filepath.Join(tempDir, "include_test.sls")
@@ -378,8 +373,7 @@ data:
 		t.Run(testName, func(t *testing.T) {
 			args := []string{
 				"-k", pgpKeyName,
-				"--pubring", publicKeyRing,
-				"--secring", secretKeyRing,
+				"--gnupg-home", gnupgHome,
 			}
 			args = append(args, cmdArgs...)
 
@@ -419,7 +413,7 @@ func TestResourceCleanup(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pgpKeyName, publicKeyRing, secretKeyRing := getTestKeyRings()
+	pgpKeyName, gnupgHome := getTestKeyInfo()
 
 	// Perform multiple operations that could create temporary resources
 	dir, err := os.Getwd()
@@ -431,8 +425,7 @@ func TestResourceCleanup(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		cmd := exec.Command(binaryPath,
 			"-k", pgpKeyName,
-			"--pubring", publicKeyRing,
-			"--secring", secretKeyRing,
+			"--gnupg-home", gnupgHome,
 			"keys", "all", "-f", testFile)
 
 		_, err := cmd.CombinedOutput()

--- a/testdata/testkeys.sh
+++ b/testdata/testkeys.sh
@@ -8,31 +8,34 @@ PATH=$PATH:/usr/local/bin
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 echo $DIR
 
-# find the gpg binary
-if command -v gpg1 &> /dev/null; then
-  GPG=gpg1
+# find the gpg binary (prefer gpg2, fall back to gpg)
+if command -v gpg2 &> /dev/null; then
+  GPG=gpg2
+elif command -v gpg &> /dev/null; then
+  GPG=gpg
 else
-  if command -v gpg &> /dev/null; then
-    GPG=gpg
-  else
-    echo "cannot find gpg binary"
+  echo "cannot find gpg binary"
+  exit 1
+fi
+
+# test the gpg version (requires gpg 2.x)
+GPG_MAJOR_VERSION=$($GPG --version | head -1 | cut -d ' ' -f 3 | cut -d '.' -f 1)
+if [[ $GPG_MAJOR_VERSION != "2" ]]; then
+    echo "GnuPG 2.x required for tests (found version $GPG_MAJOR_VERSION)"
     exit 1
-  fi
 fi
 
-# test the gpg version (only works with gpg1)
-GPG_MAJOR_VERSION=`$GPG --version | head -1 | cut -d ' ' -f 3 | cut -d '.' -f 1`
-if [[ $GPG_MAJOR_VERSION != "1" ]]; then
-    echo "GNUPGv1 required for tests"
-    exit -1;
-fi
+GNUPGHOME=$DIR/gnupg
+export GNUPGHOME
 
-mkdir -p $DIR/gnupg
-chmod 700 $DIR/gnupg
-$GPG --homedir $DIR/gnupg/ --gen-key --batch < $DIR/gpginit.txt
-$GPG --homedir $DIR/gnupg/ --expert --armor --export | $GPG --homedir $DIR/gnupg/ --import
-$GPG --homedir $DIR/gnupg/ --expert --armor --export-secret-key | $GPG --homedir $DIR/gnupg/ --import
-SECKEY=`$GPG --homedir $DIR/gnupg --list-secret-keys | grep 'sec ' | cut -d '/' -f 2 | cut -d ' ' -f 1`
-expect -c "spawn $GPG --homedir $DIR/gnupg --edit-key $SECKEY trust quit; send \"5\ry\r\"; expect eof"
+mkdir -p $GNUPGHOME
+chmod 700 $GNUPGHOME
+
+# Generate a test key with no passphrase using GnuPG 2.x batch mode
+$GPG --homedir $GNUPGHOME --batch --passphrase '' --quick-gen-key "Test Salt Master (test key)" rsa2048 encrypt,sign 0
+
+# Trust the key ultimately
+KEYID=$($GPG --homedir $GNUPGHOME --list-keys --with-colons | grep '^fpr' | head -1 | cut -d ':' -f 10)
+echo -e "5\ny\n" | $GPG --homedir $GNUPGHOME --batch --command-fd 0 --edit-key $KEYID trust quit 2>/dev/null || true
 
 exit 0


### PR DESCRIPTION
# v2.0.0: GnuPG 2.x support

## Summary

Drop GnuPG 1.x support entirely and switch to reading keys from the GnuPG 2.x agent via `gpg --export` / `gpg --export-secret-keys` subprocess calls. Replace the abandoned `keybase/go-crypto` dependency with the actively maintained `ProtonMail/go-crypto`.

## Motivation

GnuPG 2.1+ removed the legacy `secring.gpg` file. Secret keys are now managed exclusively by `gpg-agent` and stored in `private-keys-v1.d/` in an internal format. The previous approach of reading `secring.gpg` directly doesn't work on any modern GnuPG installation unless the user manually exports keys into the legacy format.

The `keybase/go-crypto` dependency hasn't been updated since 2020.

## Changes

### `pki/pki.go`

- Replace `keybase/go-crypto/openpgp` with `ProtonMail/go-crypto/openpgp`
- Remove direct keyring file reading (`setKeyRing` / `os.Open` on `.gpg` files)
- Add `findGPGBinary()` — locates `gpg2` or `gpg` in `$PATH`
- Add `exportKeysFromGPG(gnupgHome, secret)` — runs `gpg --export` or `gpg --export-secret-keys` and parses the output with `openpgp.ReadKeyRing()`
- Change `pki.New()` signature from `New(pgpKeyName, publicKeyRing, secretKeyRing)` to `New(pgpKeyName, gnupgHome)`
- Remove `PublicKeyRing` / `SecretKeyRing` fields from `Pki` struct, add `GnupgHome`
- Fix API differences: dereference `*p.SecRing` for `ReadMessage` (ProtonMail's `KeyRing` interface has a value receiver), remove second arg from `KeysById`

### `cmd/root.go`

- Remove `--pubring` and `--secring` CLI flags
- Add `--gnupg-home` flag (defaults to `~/.gnupg` or `$GNUPGHOME`)
- Simplify profile reading — only `gnupg_home` and `default_key` are extracted
- Remove unused `go-expand-tilde` import
- Bump version to 2.0.0

### `testdata/testkeys.sh`

- Rewrite for GnuPG 2.x: use `gpg --quick-gen-key` instead of `gpg --gen-key --batch`
- Require version 2.x explicitly

### `main_test.go`

- Replace `getTestKeyRings()` (3 return values) with `getTestKeyInfo()` (2 return values: `pgpKeyName`, `gnupgHome`)
- Update all `pki.New()` calls to 2-arg form
- Update `teardownGPGDir()` to clean all gnupg directory contents

### `security_test.go`

- Replace all `--pubring` / `--secring` flag references with `--gnupg-home`

### `config_example.yaml`

- Remove `default_pub_ring` and `default_sec_ring` fields

### `go.mod`

- Replace `github.com/keybase/go-crypto` with `github.com/ProtonMail/go-crypto v1.1.6`
- Remove `gopkg.in/mattes/go-expand-tilde.v1`
- Add `github.com/cloudflare/circl` and `golang.org/x/crypto` as indirect deps

### `README.md`

- Document GnuPG 2.x requirement
- Add upgrade guide from 1.x
- Update global options

## Breaking changes

- Requires GnuPG 2.x — the `gpg` or `gpg2` binary must be in `$PATH`
- `--pubring` and `--secring` CLI flags removed, replaced by `--gnupg-home`
- `pki.New()` API changed from 3 args to 2
- Config file profile fields `default_pub_ring` and `default_sec_ring` no longer recognized

## Testing

Run `go mod tidy && go build && go test ./...` with GnuPG 2.x installed. The test setup script generates a throwaway key pair in `testdata/gnupg/` using `gpg --quick-gen-key`.
